### PR TITLE
Require active_support in main file

### DIFF
--- a/lib/collection_json_serializer.rb
+++ b/lib/collection_json_serializer.rb
@@ -20,3 +20,6 @@ require "collection_json_serializer/validator/types/value"
 require "collection_json_serializer/objects/item"
 require "collection_json_serializer/objects/template"
 require "collection_json_serializer/objects/query"
+
+require "active_support/core_ext/object/blank"
+require "active_support/json"

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -7,9 +7,6 @@ require "fixtures/poro"
 require "fixtures/models"
 Dir.glob(File.dirname(__FILE__) + "/fixtures/serializers/**/*.rb") { |file| require file }
 
-require "active_support/json"
-require "active_support/inflector"
-
 module TestHelper
   def empty_serializer_for(object)
     serializer = CollectionJson::Serializer.new(object)


### PR DESCRIPTION
I couldn't get the examples to run until I tracked down which methods from ActiveSupport are used in the gem and required them manually.

I added the requires to the main `lib` file and consequently they are not needed in the test helper. I didn't see anything from inflector being used, just json and the present? method.

I don't use Rails, so let me know if I got any of this wrong. I'll be watching this gem closely!