### PR TITLE
Allow each item attribute to be added separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ class UserSerializer < CollectionJson::Serializer
   }
 
   item do
-    attributes :id, name: { prompt: "Your full name" }, :email
+    attributes :id, {name: { prompt: "Your full name" }}, :email
+	# You can also add each attribute on a single line
+	attribute date_created: { prompt: "Member since"}
     href "http://example.com/users/{id}"
     link avatar: { href: "http://assets.example.com/avatar.jpg", render: "image" }
   end

--- a/lib/collection_json_serializer/items.rb
+++ b/lib/collection_json_serializer/items.rb
@@ -18,6 +18,11 @@ module CollectionJson
         @attributes ||= args
       end
 
+      def attribute(args)
+        @attributes = Array.new unless @attributes.is_a?(Array)
+        @attributes << args
+      end
+
       def link(args)
         @links = Array.new unless @links.is_a?(Array)
         @links << args

--- a/test/fixtures/serializers/user_serializer.rb
+++ b/test/fixtures/serializers/user_serializer.rb
@@ -22,7 +22,7 @@ class UserSerializer < CollectionJson::Serializer
   items do
     href "http://example.com/users/{id}"
     attributes :name, :email
-    attribute date_created: { prompt: "Member since"}
+    attribute date_created: { prompt: "Member since" }
     link avatar: { href: "http://assets.example.com/avatar.jpg" }
     link bio: { href: "http://example.com/bio" }
   end

--- a/test/fixtures/serializers/user_serializer.rb
+++ b/test/fixtures/serializers/user_serializer.rb
@@ -22,6 +22,7 @@ class UserSerializer < CollectionJson::Serializer
   items do
     href "http://example.com/users/{id}"
     attributes :name, :email
+    attribute date_created: { prompt: "Member since"}
     link avatar: { href: "http://assets.example.com/avatar.jpg" }
     link bio: { href: "http://example.com/bio" }
   end

--- a/test/objects/item_test.rb
+++ b/test/objects/item_test.rb
@@ -8,8 +8,10 @@ module CollectionJson
           include TestHelper
 
           def setup
-            @user1 = User.new(name: "Carles Jove", email: "hola@carlus.cat", date_created: "2015-02-01")
-            @user2 = User.new(name: "Aina Jove", email: "hola@example.com", date_created: "2015-02-02")
+            @user1 = User.new(name: "Carles Jove", email: "hola@carlus.cat",
+                              date_created: "2015-02-01")
+            @user2 = User.new(name: "Aina Jove", email: "hola@example.com",
+                              date_created: "2015-02-02")
             @user_serializer = UserSerializer.new(@user1)
             @item = Item.new(@user_serializer)
           end
@@ -20,7 +22,11 @@ module CollectionJson
               data: [
                 { name: "name", value: "Carles Jove" },
                 { name: "email", value: "hola@carlus.cat" },
-                { name: "date_created", value: "2015-02-01", prompt: "Member since" }
+                {
+                  name: "date_created",
+                  value: "2015-02-01",
+                  prompt: "Member since"
+                }
               ],
               links: [
                 {
@@ -48,7 +54,11 @@ module CollectionJson
               data: [
                 { name: "name", value: "Aina Jove" },
                 { name: "email", value: "hola@example.com" },
-                { name: "date_created", value: "2015-02-02", prompt: "Member since" }
+                {
+                  name: "date_created",
+                  value: "2015-02-02",
+                  prompt: "Member since"
+                }
               ],
               links: [
                 {

--- a/test/objects/item_test.rb
+++ b/test/objects/item_test.rb
@@ -8,8 +8,8 @@ module CollectionJson
           include TestHelper
 
           def setup
-            @user1 = User.new(name: "Carles Jove", email: "hola@carlus.cat")
-            @user2 = User.new(name: "Aina Jove", email: "hola@example.com")
+            @user1 = User.new(name: "Carles Jove", email: "hola@carlus.cat", date_created: "2015-02-01")
+            @user2 = User.new(name: "Aina Jove", email: "hola@example.com", date_created: "2015-02-02")
             @user_serializer = UserSerializer.new(@user1)
             @item = Item.new(@user_serializer)
           end
@@ -19,7 +19,8 @@ module CollectionJson
               href: "http://example.com/users/#{@user1.id}",
               data: [
                 { name: "name", value: "Carles Jove" },
-                { name: "email", value: "hola@carlus.cat" }
+                { name: "email", value: "hola@carlus.cat" },
+                { name: "date_created", value: "2015-02-01", prompt: "Member since" }
               ],
               links: [
                 {
@@ -46,7 +47,8 @@ module CollectionJson
               href: "http://example.com/users/#{@user2.id}",
               data: [
                 { name: "name", value: "Aina Jove" },
-                { name: "email", value: "hola@example.com" }
+                { name: "email", value: "hola@example.com" },
+                { name: "date_created", value: "2015-02-02", prompt: "Member since" }
               ],
               links: [
                 {

--- a/test/serializer/dsl_test.rb
+++ b/test/serializer/dsl_test.rb
@@ -4,7 +4,8 @@ module CollectionJson
   class Serializer
     class TestDSL < Minitest::Test
       def setup
-        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat")
+        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat",
+                         date_created: "2015-02-01")
         @serializer = Serializer.new(@user)
       end
 

--- a/test/serializer/items/attributes_test.rb
+++ b/test/serializer/items/attributes_test.rb
@@ -4,12 +4,14 @@ module CollectionJson
   class Serializer
     class TestAttributes < Minitest::Test
       def setup
-        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat", date_created: "2015-02-01")
+        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat",
+                         date_created: "2015-02-01")
         @user_serializer = UserSerializer.new(@user)
       end
 
       def test_attributes_properties
-        assert_equal [:name, :email, {:date_created=>{:prompt=>"Member since"}}], @user_serializer.items.attributes
+        expected_attributes = [:name, :email, { date_created: { prompt: "Member since" } }]
+        assert_equal expected_attributes, @user_serializer.items.attributes
       end
     end
   end

--- a/test/serializer/items/attributes_test.rb
+++ b/test/serializer/items/attributes_test.rb
@@ -4,12 +4,12 @@ module CollectionJson
   class Serializer
     class TestAttributes < Minitest::Test
       def setup
-        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat")
+        @user = User.new(name: "Carles Jove", email: "hola@carlus.cat", date_created: "2015-02-01")
         @user_serializer = UserSerializer.new(@user)
       end
 
       def test_attributes_properties
-        assert_equal [:name, :email], @user_serializer.items.attributes
+        assert_equal [:name, :email, {:date_created=>{:prompt=>"Member since"}}], @user_serializer.items.attributes
       end
     end
   end


### PR DESCRIPTION
Just an idea. I'd find it useful to be able to define each item attribute one-by-one (on separate lines) rather than all together, e.g.:

    items do
        attribute :name
        attribute :email
    end

This works exactly the same as how each link is added to an item one by one, rather than setting `links` all at once.

This commit still keeps the old behavior of the `attributes()` method. It might be confusing to support both, as you can mix both styles if `attributes` is called first.

An even better improvement would be to change it to work like Serializer.template which can be invoked multiple times but can also accept more than one argument at a time.